### PR TITLE
OpenSlide should autodetect file type

### DIFF
--- a/iipsrv/src/IIPImage.cc
+++ b/iipsrv/src/IIPImage.cc
@@ -40,6 +40,7 @@
 #include <ctime>
 #include <limits>
 
+#include "openslide.h"
 
 using namespace std;
 
@@ -121,16 +122,10 @@ void IIPImage::testImageType() throw(file_error)
     unsigned char lbigtiff[4] = {0x4D,0x4D,0x00,0x2B}; // Little Endian BigTIFF
     unsigned char bbigtiff[4] = {0x49,0x49,0x2B,0x00}; // Big Endian BigTIFF
 
-
-    // Compare our header sequence to our magic byte signatures
-    if (suffix=="vtif" ||
-        suffix=="svs" || 
-        suffix=="ndpi" || 
-        suffix=="mrxs" || 
-        suffix=="vms" || 
-        suffix=="scn" || 
-        suffix=="bif")
+    const char * vendor = openslide_detect_vendor( path.c_str() );
+    if ( vendor != NULL && !strcmp(vendor, "generic-tiff") )
     	format = OPENSLIDE;
+    // Compare our header sequence to our magic byte signatures
     else if( memcmp( header, j2k, 10 ) == 0 ) format = JPEG2000;
     else if( memcmp( header, stdtiff, 3 ) == 0
 	     || memcmp( header, lsbtiff, 4 ) == 0 || memcmp( header, msbtiff, 4 ) == 0

--- a/iipsrv/src/IIPImage.cc
+++ b/iipsrv/src/IIPImage.cc
@@ -123,7 +123,7 @@ void IIPImage::testImageType() throw(file_error)
     unsigned char bbigtiff[4] = {0x49,0x49,0x2B,0x00}; // Big Endian BigTIFF
 
     const char * vendor = openslide_detect_vendor( path.c_str() );
-    if ( vendor != NULL && !strcmp(vendor, "generic-tiff") )
+    if ( vendor != NULL && strcmp(vendor, "generic-tiff") )
     	format = OPENSLIDE;
     // Compare our header sequence to our magic byte signatures
     else if( memcmp( header, j2k, 10 ) == 0 ) format = JPEG2000;


### PR DESCRIPTION
File extension capitalization used to affect how the files were read which caused quirks. We can try to read everything with OpenSlide and if it fails, run iipsrv standard image viewer code.

Notice that "suffix='tiff'" was not one of the conditions. That's why all tiff files were to be opened with other than OpenSlide. This always works because it turns out that tiff wsi keeps the original image as the main image so any tiff viewer can view tiff wsi, but OpenSlide can only read tiff wsi. The new code also early rejects any OpenSlide incompatible tiff early, so it continues its good behavior.

I added code to skip OpenSlide for generic tiff because iipimage also supports these; this was the previous behavior and it can be changed.

## Summary
<!--- Describe the changes in more detail. Feel free to include screenshots if relevant. -->

## Motivation
<!--- Why have you made this Pull Request? Does this fix an open issue? -->

Moving toward checking internal headers rather than file extension

## Testing
It still correctly rejects non-wsi tiff to pass to openslide.

## Questions
<!--- Are there any aspects you're unsure about? Are you looking for any feedback? -->

<!--- Mark a pull request as a draft to signal that it is not ready for review. -->
